### PR TITLE
`query_stats_readable?` support for newer rails/pg/arel gem

### DIFF
--- a/lib/pghero/methods/query_stats.rb
+++ b/lib/pghero/methods/query_stats.rb
@@ -35,7 +35,14 @@ module PgHero
       end
 
       def query_stats_readable?
-        select_all("SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')").first["has_table_privilege"] == "t"
+        has_table_privilege = select_all("SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')").first["has_table_privilege"]
+
+        case has_table_privilege
+        when String    then has_table_privilege == 't'
+        when TrueClass then has_table_privilege
+        else
+          false
+        end
       rescue ActiveRecord::StatementInvalid
         false
       end


### PR DESCRIPTION
Some gem in my stack has been updated so that `SELECT_ALL` returns `true`,
while the `PgHero.query_stats_readable?` method [expects it to return the
string `'t'`](https://github.com/ankane/pghero/blob/master/lib/pghero/methods/query_stats.rb#L38)

Output before:

```
[1] pry(main)> PgHero.query_stats_enabled?
   (0.4ms)  SELECT COUNT(*) AS count FROM pg_extension WHERE extname = 'pg_stat_statements'
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> false
[2] pry(main)> PgHero.send :select_all, "SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')"
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> [{"has_table_privilege"=>true}]
```

Output after:

```
[1] pry(main)> PgHero.query_stats_enabled?
   (0.5ms)  SELECT COUNT(*) AS count FROM pg_extension WHERE extname = 'pg_stat_statements'
   (0.3ms)  SELECT has_table_privilege(current_user, 'pg_stat_statements', 'SELECT')
=> true
```

This is using Rails 5.0.0.1, PostgreSQL 9.5.3, pg gem 0.18.4, Arel 7.1.1, but
I'm not sure which is the actual culprit.
